### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/acsApp/src/drvMCB4B.cc
+++ b/acsApp/src/drvMCB4B.cc
@@ -68,7 +68,7 @@ int MCB4B_num_cards = 0;
 
 /*----------------functions-----------------*/
 STATIC int recv_mess(int, char *, int);
-STATIC RTN_STATUS send_mess(int, const char *, char *);
+STATIC RTN_STATUS send_mess(int, const char *, const char *);
 STATIC void start_status(int card);
 STATIC int set_status(int card, int signal);
 static long report(int level);
@@ -264,7 +264,7 @@ STATIC int set_status(int card, int signal)
     /* Test for post-move string. */
     if ((status.Bits.RA_DONE || ls_active == true) && nodeptr != 0 && nodeptr->postmsgptr != 0)
     {
-        send_mess(card, nodeptr->postmsgptr, (char*) NULL);
+        send_mess(card, nodeptr->postmsgptr, NULL);
         /* The MCB4B always sends back a response, read it and discard */
         recv_mess(card, buff, WAIT);
         nodeptr->postmsgptr = NULL;
@@ -279,7 +279,7 @@ STATIC int set_status(int card, int signal)
 /* send a message to the MCB4B board                 */
 /* send_mess()                                       */
 /*****************************************************/
-STATIC RTN_STATUS send_mess(int card, const char *com, char *name)
+STATIC RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct MCB4Bcontroller *cntrl;
     size_t nwrite;


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.